### PR TITLE
Support empty fields and types

### DIFF
--- a/test/corpus/test_with_comma.txt
+++ b/test/corpus/test_with_comma.txt
@@ -1,35 +1,34 @@
 ==================
 Test with comma
 ==================
-
-1,"Apple, Microsoft",Google,3,-213.25,38.94,Meta & Instagram,0.8
-2,"Music",Dance,999,0,111.111,Simon & Garfunkel,0.00001
+1,"Apple, Microsoft",Google,3,-213.25,,Meta & Instagram,0.8
+2,"Music",Dance,999,0,,Simon & Garfunkel,0.00001
+,"Music",Dub,500,0,,Chat & Fob,0.7
 
 
 ---
 
 (csv
     (row
-    (cycle7
-        (first)
-        (second)
-        (third)
-        (fourth)
-        (fifth)
-        (sixth)
-        (seventh))
-    (ERROR)
-    (remainder
-        (first)))
+        (first (number))
+        (second (text))
+        (third (text))
+        (fourth (number))
+        (fifth (float))
+        (seventh (text))
+        (first (float)))
     (row
-    (cycle7
-        (first)
-        (second)
-        (third)
-        (fourth)
-        (fifth)
-        (sixth)
-        (seventh))
-    (ERROR)
-    (remainder
-        (first))))
+        (first (number))
+        (second (text))
+        (third (text))
+        (fourth (number))
+        (fifth (number))
+        (seventh (text))
+        (first (float)))
+    (row
+        (second (text))
+        (third (text))
+        (fourth (number))
+        (fifth (number))
+        (seventh (text))
+        (first (float))))

--- a/test/corpus/test_with_comma.txt
+++ b/test/corpus/test_with_comma.txt
@@ -1,6 +1,6 @@
-==================
+===============
 Test with comma
-==================
+===============
 1,"Apple, Microsoft",Google,3,-213.25,,Meta & Instagram,0.8
 2,"Music",Dance,999,0,,Simon & Garfunkel,0.00001
 ,"Music",Dub,500,0,,Chat & Fob,0.7

--- a/test/corpus/test_with_pipe.txt
+++ b/test/corpus/test_with_pipe.txt
@@ -1,35 +1,34 @@
 ==================
-Test with pipe
+Test with comma
 ==================
-
-1|"Apple| Microsoft"|Google|3|-213.25|38.94|Meta & Instagram|0.8
-2|"Music"|Dance|999|0|111.111|Simon & Garfunkel|0.00001
+1|"Apple| Microsoft"|Google|3|-213.25||Meta & Instagram|0.8
+2|"Music"|Dance|999|0||Simon & Garfunkel|0.00001
+|"Music"|Dub|500|0||Chat & Fob|0.7
 
 
 ---
 
 (csv
     (row
-    (cycle7
-        (first)
-        (second)
-        (third)
-        (fourth)
-        (fifth)
-        (sixth)
-        (seventh))
-    (ERROR)
-    (remainder
-        (first)))
+        (first (number))
+        (second (text))
+        (third (text))
+        (fourth (number))
+        (fifth (float))
+        (seventh (text))
+        (first (float)))
     (row
-    (cycle7
-        (first)
-        (second)
-        (third)
-        (fourth)
-        (fifth)
-        (sixth)
-        (seventh))
-    (ERROR)
-    (remainder
-        (first))))
+        (first (number))
+        (second (text))
+        (third (text))
+        (fourth (number))
+        (fifth (number))
+        (seventh (text))
+        (first (float)))
+    (row
+        (second (text))
+        (third (text))
+        (fourth (number))
+        (fifth (number))
+        (seventh (text))
+        (first (float))))

--- a/test/corpus/test_with_pipe.txt
+++ b/test/corpus/test_with_pipe.txt
@@ -1,6 +1,6 @@
-==================
-Test with comma
-==================
+==============
+Test with pipe
+==============
 1|"Apple| Microsoft"|Google|3|-213.25||Meta & Instagram|0.8
 2|"Music"|Dance|999|0||Simon & Garfunkel|0.00001
 |"Music"|Dub|500|0||Chat & Fob|0.7

--- a/test/corpus/test_with_semicolon.txt
+++ b/test/corpus/test_with_semicolon.txt
@@ -1,6 +1,6 @@
-==================
-Test with comma
-==================
+===================
+Test with semicolon
+===================
 1;"Apple; Microsoft";Google;3;-213.25;;Meta & Instagram;0.8
 2;"Music";Dance;999;0;;Simon & Garfunkel;0.00001
 ;"Music";Dub;500;0;;Chat & Fob;0.7

--- a/test/corpus/test_with_semicolon.txt
+++ b/test/corpus/test_with_semicolon.txt
@@ -1,35 +1,34 @@
 ==================
-Return statements
+Test with comma
 ==================
-
-1;"Apple, Microsoft";Google;3;-213.25;38.94;Meta & Instagram;0.8
-2;"Music";Dance;999;0;111.111;Simon & Garfunkel;0.00001
+1;"Apple; Microsoft";Google;3;-213.25;;Meta & Instagram;0.8
+2;"Music";Dance;999;0;;Simon & Garfunkel;0.00001
+;"Music";Dub;500;0;;Chat & Fob;0.7
 
 
 ---
 
 (csv
     (row
-    (cycle7
-        (first)
-        (second)
-        (third)
-        (fourth)
-        (fifth)
-        (sixth)
-        (seventh))
-    (ERROR)
-    (remainder
-        (first)))
+        (first (number))
+        (second (text))
+        (third (text))
+        (fourth (number))
+        (fifth (float))
+        (seventh (text))
+        (first (float)))
     (row
-    (cycle7
-        (first)
-        (second)
-        (third)
-        (fourth)
-        (fifth)
-        (sixth)
-        (seventh))
-    (ERROR)
-    (remainder
-        (first))))
+        (first (number))
+        (second (text))
+        (third (text))
+        (fourth (number))
+        (fifth (number))
+        (seventh (text))
+        (first (float)))
+    (row
+        (second (text))
+        (third (text))
+        (fourth (number))
+        (fifth (number))
+        (seventh (text))
+        (first (float))))


### PR DESCRIPTION
Hi @weartist ,

i had some fun today fixing your tree-sitter implementation so that they work also with empty columns and adding type information like in the upstream one https://github.com/tree-sitter-grammars/tree-sitter-csv/blob/master/common/define-grammar.js .

The updated small tests in `test/corpus` work great, but i am completely clueless how to get this now into an updated zed extension!

Can you provide the finishing touches?

Thanks for your efforts, can't wait to see an updated rainbow csv.

